### PR TITLE
Feature#2-Google-maps-sdk-installation

### DIFF
--- a/App.js
+++ b/App.js
@@ -1,11 +1,16 @@
-import { StatusBar } from "expo-status-bar";
-import { StyleSheet, Text, View } from "react-native";
+import { StyleSheet, View } from "react-native";
+import React from "react";
+import MapView from "react-native-maps"
 
 export default function App() {
   return (
     <View style={styles.container}>
-      <Text>Open up App.js to start working on your app!</Text>
-      <StatusBar styile="auto" />
+      <MapView style={styles.map} initialRegion={{
+        latitude: 37.78825,
+        longitude: -122.4324,
+        latitudeDelta: 0.0922,
+        longitudeDelta: 0.0421,
+      }} />
     </View>
   );
 }
@@ -16,5 +21,9 @@ const styles = StyleSheet.create({
     backgroundColor: "#fff",
     alignItems: "center",
     justifyContent: "center",
+  },
+  map: {
+    width: "100%",
+    height: "100%",
   },
 });

--- a/package-lock.json
+++ b/package-lock.json
@@ -11,7 +11,8 @@
         "expo": "~47.0.12",
         "expo-status-bar": "~1.4.2",
         "react": "18.1.0",
-        "react-native": "0.70.5"
+        "react-native": "0.70.5",
+        "react-native-maps": "^1.4.0"
       },
       "devDependencies": {
         "@babel/core": "^7.12.9",
@@ -4680,6 +4681,11 @@
       "version": "0.25.23",
       "resolved": "https://registry.npmjs.org/@sinclair/typebox/-/typebox-0.25.23.tgz",
       "integrity": "sha512-VEB8ygeP42CFLWyAJhN5OklpxUliqdNEUcXb4xZ/CINqtYGTjL5ukluKdKzQ0iWdUxyQ7B0539PAUhHKrCNWSQ=="
+    },
+    "node_modules/@types/geojson": {
+      "version": "7946.0.10",
+      "resolved": "https://registry.npmjs.org/@types/geojson/-/geojson-7946.0.10.tgz",
+      "integrity": "sha512-Nmh0K3iWQJzniTuPRcJn5hxXkfB1T1pgB89SBig5PlJQU5yocazeu4jATJlaA0GYFKWMqDdvYemoSnF2pXgLVA=="
     },
     "node_modules/@types/istanbul-lib-coverage": {
       "version": "2.0.4",
@@ -11686,6 +11692,24 @@
       "version": "0.70.3",
       "resolved": "https://registry.npmjs.org/react-native-gradle-plugin/-/react-native-gradle-plugin-0.70.3.tgz",
       "integrity": "sha512-oOanj84fJEXUg9FoEAQomA8ISG+DVIrTZ3qF7m69VQUJyOGYyDZmPqKcjvRku4KXlEH6hWO9i4ACLzNBh8gC0A=="
+    },
+    "node_modules/react-native-maps": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/react-native-maps/-/react-native-maps-1.4.0.tgz",
+      "integrity": "sha512-asP6oVx9uF4E9U22j40q0AcSJ4v3hPBPCg1kPdlbckGXGj+z8dwwdPkQi3hUpl94odlR//v60Sw6PAEYv8zSxw==",
+      "dependencies": {
+        "@types/geojson": "^7946.0.8"
+      },
+      "peerDependencies": {
+        "react": ">= 17.0.1",
+        "react-native": ">= 0.64.3",
+        "react-native-web": ">= 0.11"
+      },
+      "peerDependenciesMeta": {
+        "react-native-web": {
+          "optional": true
+        }
+      }
     },
     "node_modules/react-native/node_modules/@react-native/normalize-color": {
       "version": "2.0.0",

--- a/package.json
+++ b/package.json
@@ -12,7 +12,8 @@
     "expo": "~47.0.12",
     "expo-status-bar": "~1.4.2",
     "react": "18.1.0",
-    "react-native": "0.70.5"
+    "react-native": "0.70.5",
+    "react-native-maps": "^1.4.0"
   },
   "devDependencies": {
     "@babel/core": "^7.12.9",


### PR DESCRIPTION
Installation of the Google maps SDK to be able to perform the point localization and to be able to make the corresponding layouts

# Description
### What?
- Google maps SDK installation

- See Initializing the React Native project #3    for more information
### Why
- to be able to ping locations and to be able to import the module to make screen layouts
- See Initializing the React Native project #3     for more information.

## Testing

- Since the project is just initialized you only need install the basic packages to visualize the application
```npm install```
- then you can initialize with an android emulator or via web
```npm start```

## Screenshots
| Proposed design   |      Successful design      |
|----------|:-------------:|
|  ![image](https://user-images.githubusercontent.com/101743518/219510055-4b7dd118-3a02-4419-bb03-db7878b9106a.png) | ![image](https://user-images.githubusercontent.com/101743518/219515323-d3fd4e4b-1e6a-442a-9893-8ffcc5f6688c.png) |

