### PR TITLE
Feature#3-Install-react-native-paper

### DIFF
--- a/App.js
+++ b/App.js
@@ -1,16 +1,22 @@
 import { StyleSheet, View } from "react-native";
 import React from "react";
-import MapView from "react-native-maps"
+import { TextInput } from 'react-native-paper';
 
 export default function App() {
   return (
     <View style={styles.container}>
-      <MapView style={styles.map} initialRegion={{
-        latitude: 37.78825,
-        longitude: -122.4324,
-        latitudeDelta: 0.0922,
-        longitudeDelta: 0.0421,
-      }} />
+      <TextInput
+        label="Correo"
+        placeholder="Correo Electronico"
+        mode="outlined"
+        width={300}
+      />
+      <TextInput
+        label="Contraseña"
+        placeholder="contraseña"
+        mode="outlined"
+        width={300}
+      />
     </View>
   );
 }
@@ -21,9 +27,5 @@ const styles = StyleSheet.create({
     backgroundColor: "#fff",
     alignItems: "center",
     justifyContent: "center",
-  },
-  map: {
-    width: "100%",
-    height: "100%",
-  },
+  }
 });

--- a/package-lock.json
+++ b/package-lock.json
@@ -12,7 +12,9 @@
         "expo-status-bar": "~1.4.2",
         "react": "18.1.0",
         "react-native": "0.70.5",
-        "react-native-maps": "^1.4.0"
+        "react-native-maps": "^1.4.0",
+        "react-native-paper": "^5.2.0",
+        "react-native-safe-area-context": "^4.5.0"
       },
       "devDependencies": {
         "@babel/core": "^7.12.9",
@@ -1783,6 +1785,18 @@
       },
       "engines": {
         "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@callstack/react-theme-provider": {
+      "version": "3.0.8",
+      "resolved": "https://registry.npmjs.org/@callstack/react-theme-provider/-/react-theme-provider-3.0.8.tgz",
+      "integrity": "sha512-5U231sYY2sqQOaELX0WBCn+iluV8bFaXIS7em03k4W5Xz0AhGvKlnpLIhDGFP8im/SvNW7/2XoR0BsClhn9t6Q==",
+      "dependencies": {
+        "deepmerge": "^3.2.0",
+        "hoist-non-react-statics": "^3.3.0"
+      },
+      "peerDependencies": {
+        "react": ">=16.3.0"
       }
     },
     "node_modules/@eslint/eslintrc": {
@@ -5901,6 +5915,15 @@
         "node": ">=0.10.0"
       }
     },
+    "node_modules/color": {
+      "version": "3.2.1",
+      "resolved": "https://registry.npmjs.org/color/-/color-3.2.1.tgz",
+      "integrity": "sha512-aBl7dZI9ENN6fUGC7mWpMTPNHmWUSNan9tuWN6ahh5ZLNk9baLJOnSMlrQkHcrfFgz2/RigjUVAjdx36VcemKA==",
+      "dependencies": {
+        "color-convert": "^1.9.3",
+        "color-string": "^1.6.0"
+      }
+    },
     "node_modules/color-convert": {
       "version": "1.9.3",
       "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-1.9.3.tgz",
@@ -5913,6 +5936,15 @@
       "version": "1.1.3",
       "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.3.tgz",
       "integrity": "sha512-72fSenhMw2HZMTVHeCA9KCmpEIbzWiQsjN+BHcBbS9vr1mtt+vJjPdksIBNUmKAW8TFUDPJK5SUU3QhE9NEXDw=="
+    },
+    "node_modules/color-string": {
+      "version": "1.9.1",
+      "resolved": "https://registry.npmjs.org/color-string/-/color-string-1.9.1.tgz",
+      "integrity": "sha512-shrVawQFojnZv6xM40anx4CkoDP+fZsw/ZerEMsW/pyzsRbElpsL/DBVW7q3ExxwusdNXI3lXpuhEZkzs8p5Eg==",
+      "dependencies": {
+        "color-name": "^1.0.0",
+        "simple-swizzle": "^0.2.2"
+      }
     },
     "node_modules/colorette": {
       "version": "1.4.0",
@@ -8252,6 +8284,19 @@
       "engines": {
         "node": ">=8"
       }
+    },
+    "node_modules/hoist-non-react-statics": {
+      "version": "3.3.2",
+      "resolved": "https://registry.npmjs.org/hoist-non-react-statics/-/hoist-non-react-statics-3.3.2.tgz",
+      "integrity": "sha512-/gGivxi8JPKWNm/W0jSmzcMPpfpPLc3dY/6GxhX2hQ9iGj3aDfklV4ET7NjKpSinLpJ5vafa9iiGIEZg10SfBw==",
+      "dependencies": {
+        "react-is": "^16.7.0"
+      }
+    },
+    "node_modules/hoist-non-react-statics/node_modules/react-is": {
+      "version": "16.13.1",
+      "resolved": "https://registry.npmjs.org/react-is/-/react-is-16.13.1.tgz",
+      "integrity": "sha512-24e6ynE2H+OKt4kqsOvNd8kBpV65zoxbA4BVsEOB3ARVWQki/DHzaUoC5KuON/BiccDaCCTZBuOcfZs70kR8bQ=="
     },
     "node_modules/hosted-git-info": {
       "version": "3.0.8",
@@ -11711,6 +11756,31 @@
         }
       }
     },
+    "node_modules/react-native-paper": {
+      "version": "5.2.0",
+      "resolved": "https://registry.npmjs.org/react-native-paper/-/react-native-paper-5.2.0.tgz",
+      "integrity": "sha512-FfKvfh4nBvetTusiuc1QMuNxXdNai4lthoyD+dNPM03RnIapcjoKHrhCD1EvVi5c1kBSKHrlXQ3OAW/8QCQXNw==",
+      "dependencies": {
+        "@callstack/react-theme-provider": "^3.0.8",
+        "color": "^3.1.2",
+        "use-event-callback": "^0.1.0"
+      },
+      "peerDependencies": {
+        "react": "*",
+        "react-native": "*",
+        "react-native-safe-area-context": "*",
+        "react-native-vector-icons": "*"
+      }
+    },
+    "node_modules/react-native-safe-area-context": {
+      "version": "4.5.0",
+      "resolved": "https://registry.npmjs.org/react-native-safe-area-context/-/react-native-safe-area-context-4.5.0.tgz",
+      "integrity": "sha512-0WORnk9SkREGUg2V7jHZbuN5x4vcxj/1B0QOcXJjdYWrzZHgLcUzYWWIUecUPJh747Mwjt/42RZDOaFn3L8kPQ==",
+      "peerDependencies": {
+        "react": "*",
+        "react-native": "*"
+      }
+    },
     "node_modules/react-native/node_modules/@react-native/normalize-color": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/@react-native/normalize-color/-/normalize-color-2.0.0.tgz",
@@ -12326,6 +12396,19 @@
       "engines": {
         "node": ">= 5.10.0"
       }
+    },
+    "node_modules/simple-swizzle": {
+      "version": "0.2.2",
+      "resolved": "https://registry.npmjs.org/simple-swizzle/-/simple-swizzle-0.2.2.tgz",
+      "integrity": "sha512-JA//kQgZtbuY83m+xT+tXJkmJncGMTFT+C+g2h2R9uxkYIrE2yy9sgmcLhCnw57/WSD+Eh3J97FPEDFnbXnDUg==",
+      "dependencies": {
+        "is-arrayish": "^0.3.1"
+      }
+    },
+    "node_modules/simple-swizzle/node_modules/is-arrayish": {
+      "version": "0.3.2",
+      "resolved": "https://registry.npmjs.org/is-arrayish/-/is-arrayish-0.3.2.tgz",
+      "integrity": "sha512-eVRqCvVlZbuw3GrM63ovNSNAeA1K16kaR/LRY/92w0zxQ5/1YzwblUX652i4Xs9RwAGjW9d9y6X88t8OaAJfWQ=="
     },
     "node_modules/sisteransi": {
       "version": "1.0.5",
@@ -13573,6 +13656,14 @@
       "integrity": "sha512-cwESVXlO3url9YWlFW/TA9cshCEhtu7IKJ/p5soJ/gGpj7vbvFrAY/eIioQ6Dw23KjZhYgiIo8HOs1nQ2vr/oQ==",
       "engines": {
         "node": ">=0.10.0"
+      }
+    },
+    "node_modules/use-event-callback": {
+      "version": "0.1.0",
+      "resolved": "https://registry.npmjs.org/use-event-callback/-/use-event-callback-0.1.0.tgz",
+      "integrity": "sha512-5fTzY5UEXHMK5UR0NRkUz6TPfWmmX9fO8Tx3SnHrfMPdrQ7Rna0gDBy0r56SP68TwsP9DgwSBzeysCu3A/Z2NA==",
+      "peerDependencies": {
+        "react": ">=16.8"
       }
     },
     "node_modules/use-sync-external-store": {

--- a/package.json
+++ b/package.json
@@ -13,7 +13,9 @@
     "expo-status-bar": "~1.4.2",
     "react": "18.1.0",
     "react-native": "0.70.5",
-    "react-native-maps": "^1.4.0"
+    "react-native-maps": "^1.4.0",
+    "react-native-paper": "^5.2.0",
+    "react-native-safe-area-context": "^4.5.0"
   },
   "devDependencies": {
     "@babel/core": "^7.12.9",


### PR DESCRIPTION
installation of react-native-paper for the screen design

# Description
### What?
-  Install react-native-paper

- See Initializing the React Native project #9   for more information
### Why
- installation of react-native-paper for the screen design

- See Initializing the React Native project #9     for more information.

## Testing

- Since the project is just initialized you only need install the basic packages to visualize the application
```npm install```
- then you can initialize with an android emulator or via web
```npm start```

## Screenshots
| Proposed design   |      Successful design      |
|----------|:-------------:|
| ![image](https://user-images.githubusercontent.com/101743518/219802318-912e02f0-2571-495f-9158-66b2086cb4c0.png) | ![image](https://user-images.githubusercontent.com/101743518/219809901-6306655d-7d64-499c-9220-9b3b45a46d20.png) |
